### PR TITLE
fix: skip built-in attributes so the IDE can resolve the symbols

### DIFF
--- a/src/main/kotlin/com/github/tempest/framework/TempestFrameworkUtil.kt
+++ b/src/main/kotlin/com/github/tempest/framework/TempestFrameworkUtil.kt
@@ -3,4 +3,12 @@ package com.github.tempest.framework
 object TempestFrameworkUtil {
     const val TEMPLATE_SUFFIX = ".view.php"
     const val COMPONENT_NAME_PREFIX = "x-"
+
+    val BUILT_IN_DIRECTIVE_ATTRIBUTES = setOf(
+        ":if",
+        ":elseif",
+        ":else",
+        ":foreach",
+        ":forelse",
+    )
 }

--- a/src/main/kotlin/com/github/tempest/framework/views/references/ComponentReferenceContributor.kt
+++ b/src/main/kotlin/com/github/tempest/framework/views/references/ComponentReferenceContributor.kt
@@ -75,6 +75,10 @@ class ComponentReferenceContributor : PsiReferenceContributor() {
                     val attribute = element as? XmlAttribute ?: return emptyArray()
                     val htmlTag = attribute.parent as? HtmlTag ?: return emptyArray()
 
+                    if (attribute.name in TempestFrameworkUtil.BUILT_IN_DIRECTIVE_ATTRIBUTES) {
+                        return emptyArray()
+                    }
+
                     return arrayOf(TempestAttributeReference(element, htmlTag))
 //                        .apply { println("found references for ${element} ${this.joinToString { it.toString() }}") }
                 }


### PR DESCRIPTION
Skips reference creation for built-in attributes
